### PR TITLE
Update for GNOME 3.32, fix #10

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -43,6 +43,8 @@ let windowOverlayInjections;
 let extendedInstances;
 let settings;
 
+const windowOverlayBase = Workspace.WindowOverlay;
+
 function registerExtendedInstance(instance) {
     extendedInstances.push(instance);
 }
@@ -67,7 +69,10 @@ function resetState() {
 function enable() {
     resetState();
     
-    windowOverlayInjections['_init'] = injectToFunction(Workspace.WindowOverlay.prototype, '_init', function(windowClone, parentActor) {
+    Workspace.WindowOverlay = class extends windowOverlayBase {
+      constructor(windowClone, parentActor) {            
+        super(windowClone, parentActor);
+
         this._windowOverlayIconsExtension = {};
 
         this._windowOverlayIconsExtension.box = new St.Bin({ style_class: 'windowoverlay-application-icon-box' });
@@ -102,7 +107,9 @@ function enable() {
         parentActor.set_child_below_sibling(this.border, this._windowOverlayIconsExtension.box);
 
         registerExtendedInstance(this);
-    });
+      }
+    };
+    Workspace.WindowOverlay.prototype = windowOverlayBase.prototype;
     
     windowOverlayInjections['hide'] = injectToFunction(Workspace.WindowOverlay.prototype, 'hide', function() {
         if (this._windowOverlayIconsExtension && this._windowOverlayIconsExtension.box) {
@@ -285,6 +292,7 @@ function disable() {
     }
     removeExtensionFromAllExtendedInstances();
     resetState();
+    Workspace.WindowOverlay.prototype = windowOverlayBase;
 }
 
 function init() {

--- a/prefs.js
+++ b/prefs.js
@@ -47,13 +47,12 @@ function getErrorLabel(message) {
     return label;
 }
 
-const WindowOverlayIcosExtensionPrefsWidget = new GObject.Class({
-    Name: 'WindowOverlayIconsExtension.Prefs.Widget',
-    GTypeName: 'WindowOverlayIconsExtensionPrefsWidget',
-    Extends: Gtk.Box,
-    
-    _init: function(params) {
-        this.parent(params);
+const WindowOverlayIcosExtensionPrefsWidget = GObject.registerClass(
+    class WindowOverlayIconsExtension_Prefs_Widget
+    extends Gtk.Box
+{
+    _init(params) {
+        super._init(params);
         
         try {
             this._settings = Convenience.getSettings(PREFS_SCHEMA);
@@ -86,9 +85,9 @@ const WindowOverlayIcosExtensionPrefsWidget = new GObject.Class({
         this._connectSignals(builder);
         
         this.add(this._mainGrid);
-    },
+    }
     
-    _fillData: function(builder) {
+    _fillData(builder) {
         let h = this._settings.get_enum('icon-horizontal-alignment');
         let v = this._settings.get_enum('icon-vertical-alignment');
         this._icon_alignment.current_value = 3 * (v - 1) + h;
@@ -96,7 +95,7 @@ const WindowOverlayIcosExtensionPrefsWidget = new GObject.Class({
         this._icon_size.value = this._settings.get_int('icon-size');
         this._icon_size_relative.active = this._settings.get_boolean('icon-size-relative');
         
-        [result, background_color] = Gdk.color_parse(this._settings.get_string('background-color'));
+        let [result, background_color] = Gdk.color_parse(this._settings.get_string('background-color'));
         if (result) {
             this._background_color.color = background_color;
         }
@@ -104,9 +103,9 @@ const WindowOverlayIcosExtensionPrefsWidget = new GObject.Class({
         
         this._icon_opacity_focus.value = this._settings.get_int('icon-opacity-focus');
         this._icon_opacity_blur.value = this._settings.get_int('icon-opacity-blur');
-    },
+    }
     
-    _connectSignals: function(builder) {
+    _connectSignals(builder) {
         this._icon_alignment.connect('changed', Lang.bind(this, function(action, current) {
             let h, v;
             switch (current.value) {


### PR DESCRIPTION
References:
- ES6 code style: [DreaminginCodeZH/gnome-shell-extension-es6-class-codemod](https://github.com/DreaminginCodeZH/gnome-shell-extension-es6-class-codemod)
- Use `constructor` instead of `init`:
    <https://gitlab.gnome.org/GNOME/gnome-shell/blob/master/js/ui/workspace.js>
- Modify constructor by extending, should not inject `prototype.constructor`:
    <https://stackoverflow.com/a/9267343/10829731>

Learn a lot about javascript just to fix this extension... :stuck_out_tongue_winking_eye:
  Not a real programmer, just tried to do my best. 

**NOTE:** _lacks backward compatibility!_