### PR TITLE
Confirm support GNOME Shell v3.34

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.32"],
+    "shell-version": ["3.32", "3.34"],
     "uuid": "windowoverlay-icons@sustmidown.centrum.cz",
     "name": "WindowOverlay Icons",
     "description": "Add application icons to window overview",


### PR DESCRIPTION
Confirmed working on gnome-shell-3.34.0-2 on Fedora 31 beta.